### PR TITLE
Fix a typo in quotes.fortune

### DIFF
--- a/quotes.fortune
+++ b/quotes.fortune
@@ -28,7 +28,7 @@ there will be no peace.
  
   - KMFDM
 %
-Seit bereit, immer bereit.
+Seid bereit, immer bereit.
 %
 Teachers can only show the way;
 we must walk the path ourselves.


### PR DESCRIPTION
The quotes seem to include the Eastern Germany's Pioneer Organisation's motto, "Seid bereit, immer bereit" ("Be prepared, always prepared"). But the quote actually contained "Seit" ("Since") instead of "Seid" ("Be"). This PR proposes to fix that, in case that was not intentional.